### PR TITLE
Fix xml feed links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -38,7 +38,7 @@ google_analytics: UA-58671174-1
 
 # Your website URL (e.g. http://barryclark.github.io or http://www.barryclark.co)
 # Used for Sitemap.xml and your RSS feed
-url: waterbearlang.com
+url: http://waterbearlang.github.io/
 
 # If you're hosting your site at a Project repository on GitHub pages
 # (http://yourusername.github.io/repository-name)


### PR DESCRIPTION
The permalinks depend on using the _correct_ full URL to the posts; this means using `waterbearlang.github.io`.
